### PR TITLE
Setting umask for files written in var/

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -2,6 +2,8 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
+umask(0002);
+
 require __DIR__.'/../vendor/autoload.php';
 if (PHP_VERSION_ID < 70000) {
     include_once __DIR__.'/../var/bootstrap.php.cache';

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -3,10 +3,7 @@
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-// If you don't want to setup permissions the proper way, just uncomment the following PHP line
-// read https://symfony.com/doc/current/setup.html#checking-symfony-application-configuration-and-setup
-// for more information
-//umask(0000);
+umask(0002);
 
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.


### PR DESCRIPTION
See https://github.com/elifesciences/journal/commit/8107a2e0f1223cebaa0d9dfba222a6273cfeb962#diff-5f5343d10fae8e62eba1c31ba15d9dc5 for example.
The default is for files to be `rw-r--r--`, but we want them to be `rw-rw-r--` so that the `elife` user and the `www-data` user from the webserver can both use the var/ folder.

Current error:
```
Unable to create the storage directory (/srv/annotations/var/cache/dev/profiler)
```