### PR TITLE
Lazy creation of basic objects

### DIFF
--- a/src/Annotations/Kernel.php
+++ b/src/Annotations/Kernel.php
@@ -247,8 +247,6 @@ final class Kernel implements MinimalKernel
 
         $app->register(new AnnotationsServiceProvider(), [
             'annotations.hypothesis.sdk' => $app['hypthesis.sdk'],
-            'annotations.limit.import' => $app->protect($app['limit.interactive']),
-            'annotations.limit.watch' => $app->protect($app['limit.long_running']),
             'annotations.logger' => $app['logger'],
             'annotations.monitoring' => $app['monitoring'],
             'annotations.api.sdk' => $app['api.sdk'],

--- a/src/Annotations/Kernel.php
+++ b/src/Annotations/Kernel.php
@@ -251,7 +251,6 @@ final class Kernel implements MinimalKernel
             'annotations.monitoring' => $app['monitoring'],
             'annotations.api.sdk' => $app['api.sdk'],
             'annotations.sqs' => $app['aws.sqs'],
-            'annotations.sqs.queue' => $app['aws.queue'],
             'annotations.sqs.queue_message_type' => $app['config']['aws']['queue_message_default_type'],
             'annotations.sqs.queue_name' => $app['config']['aws']['queue_name'],
             'annotations.sqs.queue_transformer' => $app['aws.queue_transformer'],

--- a/src/Annotations/Provider/AnnotationsServiceProvider.php
+++ b/src/Annotations/Provider/AnnotationsServiceProvider.php
@@ -30,17 +30,17 @@ class AnnotationsServiceProvider implements ServiceProviderInterface
         $container->extend('console', function (Application $console) use ($container) {
             $console->add(new QueueCleanCommand($container['aws.queue'], $container['annotations.logger']));
             $console->add(new QueueCountCommand($container['aws.queue']));
-            $console->add(new QueuePushCommand($container['annotations.sqs.queue'], $container['annotations.logger'], $container['annotations.sqs.queue_message_type'] ?? null));
+            $console->add(new QueuePushCommand($container['aws.queue'], $container['annotations.logger'], $container['annotations.sqs.queue_message_type'] ?? null));
             $console->add(new QueueCreateCommand($container['annotations.sqs'], $container['annotations.logger'], $container['annotations.sqs.queue_name'] ?? null, $container['annotations.sqs.region'] ?? null));
             $console->add(new QueueImportCommand(
                 $container['annotations.api.sdk'],
-                $container['annotations.sqs.queue'],
+                $container['aws.queue'],
                 $container['annotations.logger'],
                 $container['annotations.monitoring'],
                 $container['limit.interactive']
             ));
             $console->add(new QueueWatchCommand(
-                $container['annotations.sqs.queue'],
+                $container['aws.queue'],
                 $container['annotations.sqs.queue_transformer'],
                 $container['annotations.hypothesis.sdk'],
                 $container['annotations.logger'],

--- a/src/Annotations/Provider/AnnotationsServiceProvider.php
+++ b/src/Annotations/Provider/AnnotationsServiceProvider.php
@@ -37,7 +37,7 @@ class AnnotationsServiceProvider implements ServiceProviderInterface
                 $container['annotations.sqs.queue'],
                 $container['annotations.logger'],
                 $container['annotations.monitoring'],
-                $container['annotations.limit.import']
+                $container['limit.interactive']
             ));
             $console->add(new QueueWatchCommand(
                 $container['annotations.sqs.queue'],
@@ -45,7 +45,7 @@ class AnnotationsServiceProvider implements ServiceProviderInterface
                 $container['annotations.hypothesis.sdk'],
                 $container['annotations.logger'],
                 $container['annotations.monitoring'],
-                $container['annotations.limit.watch']
+                $container['limit.long_running']
             ));
 
             return $console;

--- a/src/Annotations/Provider/AnnotationsServiceProvider.php
+++ b/src/Annotations/Provider/AnnotationsServiceProvider.php
@@ -28,8 +28,8 @@ class AnnotationsServiceProvider implements ServiceProviderInterface
         }
 
         $container->extend('console', function (Application $console) use ($container) {
-            $console->add(new QueueCleanCommand($container['annotations.sqs.queue'], $container['annotations.logger']));
-            $console->add(new QueueCountCommand($container['annotations.sqs.queue']));
+            $console->add(new QueueCleanCommand($container['aws.queue'], $container['annotations.logger']));
+            $console->add(new QueueCountCommand($container['aws.queue']));
             $console->add(new QueuePushCommand($container['annotations.sqs.queue'], $container['annotations.logger'], $container['annotations.sqs.queue_message_type'] ?? null));
             $console->add(new QueueCreateCommand($container['annotations.sqs'], $container['annotations.logger'], $container['annotations.sqs.queue_name'] ?? null, $container['annotations.sqs.region'] ?? null));
             $console->add(new QueueImportCommand(

--- a/tests/Annotations/Provider/AnnotationsServiceProviderTest.php
+++ b/tests/Annotations/Provider/AnnotationsServiceProviderTest.php
@@ -55,12 +55,12 @@ final class AnnotationsServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->container = [
             'annotations.api.sdk' => new ApiSdk($this->httpClient),
             'annotations.hypothesis.sdk' => new HypothesisApiSdk($this->createMock(HttpClientInterface::class)),
-            'annotations.limit.import' => $this->app->protect($this->createMock(Limit::class)),
-            'annotations.limit.watch' => $this->app->protect($this->createMock(Limit::class)),
+            'limit.interactive' => $this->app->protect($this->createMock(Limit::class)),
+            'limit.long_running' => $this->app->protect($this->createMock(Limit::class)),
             'annotations.logger' => $this->logger,
             'annotations.monitoring' => new Monitoring(),
             'annotations.sqs' => $this->sqs,
-            'annotations.sqs.queue' => $this->queue,
+            'aws.queue' => $this->queue,
             'annotations.sqs.queue_transformer' => $this->createMock(QueueItemTransformer::class),
         ];
     }


### PR DESCRIPTION
When objects are requested from $app and passed to `AnnotationsServiceProvider`, they are instantiated.

This is a bit wasteful, but more importantly some of them can only be built from the cli and not in php-fpm, as our configuration disables the `pcntl_*` functions for security reasons.

We should probably go for a similar pattern for the other objects as well, but they don't break the application on our servers.