### PR TITLE
The process code was not being run in the test

### DIFF
--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -52,8 +52,8 @@ final class QueueWatchCommand extends QueueCommand
                 $email = $id.'@hypothesis.elifesciences.org';
             }
             $user = new User($id, $email, $display_name);
-            $store = $this->hypothesisSdk->users()->store($user)->wait();
-            $this->logger->info(sprintf('Hypothesis user "%s" successfully %s.', $store->getId(), ($store->isNew() ? 'created' : 'updated')));
+            $upsert = $this->hypothesisSdk->users()->upsert($user)->wait();
+            $this->logger->info(sprintf('Hypothesis user "%s" successfully %s.', $upsert->getUsername(), ($upsert->isNew() ? 'created' : 'updated')));
         }
     }
 }

--- a/tests/Annotations/Command/QueueWatchCommandTest.php
+++ b/tests/Annotations/Command/QueueWatchCommandTest.php
@@ -3,18 +3,26 @@
 namespace tests\eLife\Annotations\Command;
 
 use eLife\Annotations\Command\QueueWatchCommand;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Model\PersonDetails;
+use eLife\ApiSdk\Model\Profile;
 use eLife\Bus\Limit\CallbackLimit;
 use eLife\Bus\Limit\Limit;
 use eLife\Bus\Queue\InternalSqsMessage;
 use eLife\Bus\Queue\Mock\WatchableQueueMock;
 use eLife\Bus\Queue\QueueItemTransformer;
 use eLife\HypothesisClient\ApiSdk as HypothesisSdk;
+use eLife\HypothesisClient\Credentials\Credentials;
 use eLife\HypothesisClient\HttpClient\HttpClient;
+use eLife\HypothesisClient\Result\ArrayResult;
 use eLife\Logging\Monitoring;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use tests\eLife\HypothesisClient\RequestConstraint;
 
 /**
  * @covers \eLife\Annotations\Command\QueueWatchCommand
@@ -23,16 +31,22 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
 {
     /** @var Application */
     private $application;
+    private $authority;
+    private $authorization;
+    private $clientId;
     /** @var QueueWatchCommand */
     private $command;
     /** @var CommandTester */
     private $commandTester;
+    /** @var Credentials */
+    private $credentials;
     /** @var HypothesisSdk */
     private $hypothesisSdk;
     private $limit;
     private $logger;
     /** @var Monitoring */
     private $monitoring;
+    private $secretKey;
     private $transformer;
     /** @var WatchableQueueMock */
     private $queue;
@@ -43,18 +57,42 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
     public function prepareDependencies()
     {
         $this->application = new Application();
+        $this->clientId = 'client_id';
+        $this->secretKey = 'secret_key';
+        $this->authority = 'authority';
+        $this->authorization = sprintf('Basic %s', base64_encode($this->clientId.':'.$this->secretKey));
+        $this->credentials = new Credentials('client_id', 'secret_key', 'authority');
         $this->httpClient = $this->getMockBuilder(HttpClient::class)
             ->setMethods(['send'])
             ->getMock();
-        $this->hypothesisSdk = new HypothesisSdk($this->httpClient);
+        $this->hypothesisSdk = new HypothesisSdk($this->httpClient, $this->credentials);
         $this->limit = $this->limitIterations(1);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->monitoring = new Monitoring();
         $this->transformer = $this->createMock(QueueItemTransformer::class);
+        $data = [
+            'authority' => 'authority',
+            'username' => 'username',
+            'email' => 'username@hypothesis.elifesciences.org',
+            'display_name' => 'Preferred Name',
+        ];
+        $profile = new Profile($data['username'], new PersonDetails($data['display_name'], 'IndexName'), new ArraySequence([]), new ArraySequence([]));
         $this->transformer
             ->expects($this->any())
             ->method('transform')
-            ->will($this->returnValue(['field' => 'value']));
+            ->will($this->returnValue($profile));
+        $request = new Request(
+            'POST',
+            'users',
+            ['Authorization' => $this->authorization, 'User-Agent' => 'HypothesisClient'],
+            json_encode($data)
+        );
+        $response = new FulfilledPromise(new ArrayResult($data));
+        $this->httpClient
+            ->expects($this->once())
+            ->method('send')
+            ->with(RequestConstraint::equalTo($request))
+            ->willReturn($response);
         $this->queue = new WatchableQueueMock();
     }
 
@@ -64,7 +102,7 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
     public function it_will_read_an_item_from_the_queue()
     {
         $this->prepareCommandTester();
-        $this->queue->enqueue(new InternalSqsMessage('profile', 'id'));
+        $this->queue->enqueue(new InternalSqsMessage('profile', 'username'));
         $this->assertEquals(1, $this->queue->count());
         $this->commandTesterExecute();
         $this->assertEquals(0, $this->queue->count());


### PR DESCRIPTION
The `QueueWatchCommand` was broken. My test did not cover the code in the `process` method so it didn't catch the errors thrown when I change the client code to `Users::upsert` and `User::getUsername`.

I'm running the failing test in CI and will follow up with the fix.