### PR TITLE
Fail fast on generic Bad Response on POST /users

### DIFF
--- a/src/HypothesisClient/Client/Users.php
+++ b/src/HypothesisClient/Client/Users.php
@@ -53,7 +53,9 @@ final class Users
                  * attempt an update request.
                  */
                 if ($reason instanceof BadResponse) {
-                    return $this->update($user);
+                    if ($reason->getResponse()->getStatusCode() == 400) {
+                        return $this->update($user);
+                    }
                 }
 
                 return rejection_for($reason);

--- a/tests/HypothesisClient/Client/UsersTest.php
+++ b/tests/HypothesisClient/Client/UsersTest.php
@@ -249,4 +249,33 @@ class UsersTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($upsertedUser->isNew());
         $this->assertEquals($expectedUser, $upsertedUser);
     }
+
+    /**
+     * @test
+     */
+    public function it_will_fail_fast_on_errors_that_do_not_indicate_existing_users()
+    {
+        $post_data = [
+            'authority' => 'authority',
+            'username' => 'username',
+            'email' => 'email@email.com',
+            'display_name' => 'Display Name',
+        ];
+        $post_request = new Request(
+            'POST',
+            'users',
+            ['Authorization' => $this->authorization, 'User-Agent' => 'HypothesisClient'],
+            json_encode($post_data)
+        );
+        $post_response = new Response(405);
+        $rejected_post_response = new RejectedPromise(new BadResponse('', $post_request, $post_response));
+        $user = new User('username', 'email@email.com', 'Display Name');
+        $this->usersClient;
+        $this->httpClient
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($rejected_post_response);
+        $this->setExpectedException(BadResponse::class);
+        $this->users->upsert($user)->wait();
+    }
 }


### PR DESCRIPTION
Encountered this yesterday by chance.

This is the response in case of an already existing user:
```
HTTP/1.1 400 Bad Request\r\n
Date: Fri, 24 Nov 2017 11:34:19 GMT\r\n
Content-Type: application/json; charset=UTF-8\r\n
Content-Length: 155\r\n
...

{"status": "failure", "reason": "user with email address m8nl1gze@hypothesis.elifesciences.org already exists, user with username m8nl1gze already exists"}
```

We have decided previously not to rely on the body error message as it's brittle and it changes depending on the input. We can still check the status code as a first filter however: 405 and other 40X are still considered a `BadResponse` but they should fail immediately as they are outside of the scope of an existing user.