### PR TITLE
Stub AWS SQS in only integration test that requires it

### DIFF
--- a/config/test.php
+++ b/config/test.php
@@ -1,0 +1,7 @@
+<?php
+
+$config = require __DIR__.'/ci.php';
+
+$config['aws']['stub'] = true;
+
+return $config;

--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -283,4 +283,14 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
     {
         return isset($this->app[$id]);
     }
+
+    /**
+     * Use only in integration tests.
+     *
+     * @internal
+     */
+    public function override($id, callable $factory)
+    {
+        $this->app[$id] = $factory;
+    }
 }

--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -13,6 +13,7 @@ use eLife\Bus\Limit\CompositeLimit;
 use eLife\Bus\Limit\LoggingLimit;
 use eLife\Bus\Limit\MemoryLimit;
 use eLife\Bus\Limit\SignalsLimit;
+use eLife\Bus\Queue\Mock\WatchableQueueMock;
 use eLife\Bus\Queue\SqsMessageTransformer;
 use eLife\Bus\Queue\SqsWatchableQueue;
 use eLife\HypothesisClient\ApiSdk as HypothesisApiSdk;
@@ -64,6 +65,7 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
                 'credential_file' => true,
                 'region' => 'us-east-1',
                 'endpoint' => 'http://localhost:4100',
+                'stub' => false,
             ],
             'hypothesis' => ($config['hypothesis'] ?? []) + [
                 'api_url' => 'https://hypothes.is/api/',
@@ -240,7 +242,11 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
         };
 
         $this->app['aws.queue'] = function (Application $app) {
-            return new SqsWatchableQueue($app['aws.sqs'], $app['aws']['queue_name']);
+            if ($app['aws']['stub']) {
+                return new WatchableQueueMock();
+            } else {
+                return new SqsWatchableQueue($app['aws.sqs'], $app['aws']['queue_name']);
+            }
         };
 
         $this->app['aws.queue_transformer'] = function (Application $app) {

--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -289,14 +289,4 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
     {
         return isset($this->app[$id]);
     }
-
-    /**
-     * Use only in integration tests.
-     *
-     * @internal
-     */
-    public function override($id, callable $factory)
-    {
-        $this->app[$id] = $factory;
-    }
 }

--- a/tests/Annotations/Provider/QueueCommandsProviderTest.php
+++ b/tests/Annotations/Provider/QueueCommandsProviderTest.php
@@ -3,6 +3,7 @@
 namespace tests\eLife\Annotations\Provider;
 
 use eLife\Annotations\Provider\QueueCommandsProvider;
+use eLife\Bus\Queue\Mock\WatchableQueueMock;
 use LogicException;
 use Silex\Application;
 use tests\eLife\Annotations\WebTestCase;
@@ -12,6 +13,16 @@ use tests\eLife\Annotations\WebTestCase;
  */
 final class QueueCommandsProviderTest extends WebTestCase
 {
+    /**
+     * @before
+     */
+    public function setupSqs()
+    {
+        $this->kernel->override('aws.queue', function () {
+            return new WatchableQueueMock();
+        });
+    }
+
     /**
      * @test
      */

--- a/tests/Annotations/Provider/QueueCommandsProviderTest.php
+++ b/tests/Annotations/Provider/QueueCommandsProviderTest.php
@@ -3,7 +3,6 @@
 namespace tests\eLife\Annotations\Provider;
 
 use eLife\Annotations\Provider\QueueCommandsProvider;
-use eLife\Bus\Queue\Mock\WatchableQueueMock;
 use LogicException;
 use Silex\Application;
 use tests\eLife\Annotations\WebTestCase;
@@ -13,16 +12,6 @@ use tests\eLife\Annotations\WebTestCase;
  */
 final class QueueCommandsProviderTest extends WebTestCase
 {
-    /**
-     * @before
-     */
-    public function setupSqs()
-    {
-        $this->kernel->override('aws.queue', function () {
-            return new WatchableQueueMock();
-        });
-    }
-
     /**
      * @test
      */

--- a/tests/Annotations/WebTestCase.php
+++ b/tests/Annotations/WebTestCase.php
@@ -13,7 +13,7 @@ abstract class WebTestCase extends SilexWebTestCase
 
     public function createApplication() : HttpKernelInterface
     {
-        $this->kernel = new AppKernel('ci');
+        $this->kernel = new AppKernel('test');
 
         return $this->kernel;
     }


### PR DESCRIPTION
Wouldn't move this setup to the base `WebTestCase` as other tests should
not need it, being focused on single classes.