### PR TITLE
ELPP-3304 Use access control on emailAddresses

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c762fcf384ce7180488a1b037aa9b76",
+    "content-hash": "106c96c1cce9984ade9a2a3e78226217",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -495,7 +495,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API client",
-            "time": "2017-10-23 09:04:22"
+            "time": "2017-10-23T09:04:22+00:00"
         },
         {
             "name": "elife/api-problem",
@@ -550,12 +550,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "18da533d8e1b93cddf7d99e4bb9e9a815510f8c0"
+                "reference": "c73cafbdae1982369f1e153f14401bc12a256367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/18da533d8e1b93cddf7d99e4bb9e9a815510f8c0",
-                "reference": "18da533d8e1b93cddf7d99e4bb9e9a815510f8c0",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/c73cafbdae1982369f1e153f14401bc12a256367",
+                "reference": "c73cafbdae1982369f1e153f14401bc12a256367",
                 "shasum": ""
             },
             "require": {
@@ -590,7 +590,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2017-11-16 14:30:20"
+            "time": "2017-11-29T10:15:32+00:00"
         },
         {
             "name": "elife/bus-sdk",
@@ -638,7 +638,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences Bus SDK",
-            "time": "2017-11-16 13:04:40"
+            "time": "2017-11-16T13:04:40+00:00"
         },
         {
             "name": "elife/logging-sdk",
@@ -681,7 +681,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences logging SDK",
-            "time": "2017-09-19 06:46:12"
+            "time": "2017-09-19T06:46:12+00:00"
         },
         {
             "name": "elife/ping",

--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -2,6 +2,7 @@
 
 namespace eLife\Annotations\Command;
 
+use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\Profile;
 use eLife\Bus\Command\QueueCommand;
 use eLife\Bus\Limit\Limit;
@@ -43,7 +44,9 @@ final class QueueWatchCommand extends QueueCommand
     {
         if ($entity instanceof Profile) {
             $id = $entity->getIdentifier()->getId();
-            $emails = $entity->getEmailAddresses();
+            $emails = $entity->getEmailAddresses()->map(function (AccessControl $accessControl) {
+                return $accessControl->getValue();
+            });
             $display_name = $entity->getDetails()->getPreferredName();
             if (count($emails) > 0) {
                 $email = $emails[0];

--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -44,9 +44,14 @@ final class QueueWatchCommand extends QueueCommand
     {
         if ($entity instanceof Profile) {
             $id = $entity->getIdentifier()->getId();
-            $emails = $entity->getEmailAddresses()->map(function (AccessControl $accessControl) {
-                return $accessControl->getValue();
-            });
+            $emails = $entity
+                ->getEmailAddresses()
+                ->filter(function (AccessControl $accessControl) {
+                    return $accessControl->getAccess() == AccessControl::ACCESS_PUBLIC;
+                })
+                ->map(function (AccessControl $accessControl) {
+                    return $accessControl->getValue();
+                });
             $display_name = $entity->getDetails()->getPreferredName();
             if (count($emails) > 0) {
                 $email = $emails[0];

--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -47,7 +47,7 @@ final class QueueWatchCommand extends QueueCommand
             $emails = $entity
                 ->getEmailAddresses()
                 ->filter(function (AccessControl $accessControl) {
-                    return $accessControl->getAccess() == AccessControl::ACCESS_PUBLIC;
+                    return $accessControl->getAccess() === AccessControl::ACCESS_PUBLIC;
                 })
                 ->map(function (AccessControl $accessControl) {
                     return $accessControl->getValue();

--- a/tests/Annotations/Command/QueueWatchCommandTest.php
+++ b/tests/Annotations/Command/QueueWatchCommandTest.php
@@ -204,6 +204,23 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
                 'display_name' => 'PreferredName',
             ],
         ];
+        yield 'with restricted emails (in case authenticated API requests are used)' => [
+            new InternalSqsMessage('profile', 'username'),
+            new Profile(
+                'username',
+                new PersonDetails('PreferredName', 'IndexName'),
+                new EmptySequence(),
+                new ArraySequence([
+                    new AccessControl('restricted@email.com', AccessControl::ACCESS_RESTRICTED),
+                    new AccessControl('public@email.com', AccessControl::ACCESS_PUBLIC),
+                ])
+            ),
+            [
+                'username' => 'username',
+                'email' => 'public@email.com',
+                'display_name' => 'PreferredName',
+            ],
+        ];
     }
 
     private function prepareCommandTester($serializedTransform = false)

--- a/tests/Annotations/Command/QueueWatchCommandTest.php
+++ b/tests/Annotations/Command/QueueWatchCommandTest.php
@@ -5,6 +5,7 @@ namespace tests\eLife\Annotations\Command;
 use eLife\Annotations\Command\QueueWatchCommand;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\EmptySequence;
+use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\Profile;
 use eLife\Bus\Limit\CallbackLimit;
@@ -176,7 +177,9 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
                 'username',
                 new PersonDetails('PreferredName', 'IndexName'),
                 new EmptySequence(),
-                new ArraySequence(['username@email.com'])
+                new ArraySequence([
+                    new AccessControl('username@email.com', AccessControl::ACCESS_PUBLIC),
+                ])
             ),
             [
                 'username' => 'username',
@@ -190,7 +193,10 @@ class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
                 'username',
                 new PersonDetails('PreferredName', 'IndexName'),
                 new EmptySequence(),
-                new ArraySequence(['another@email.com', 'username@email.com'])
+                new ArraySequence([
+                    new AccessControl('another@email.com', AccessControl::ACCESS_PUBLIC),
+                    new AccessControl('username@email.com', AccessControl::ACCESS_PUBLIC),
+                ])
             ),
             [
                 'username' => 'username',


### PR DESCRIPTION
Annotations will only see public email addresses at the moment, so we don't have to filter.

However, they are now wrapped into an `AccessControl` object that specifies their access (`public` or `restricted`).