### PR TITLE
Reduce surface of JWTSigningCredentials

### DIFF
--- a/src/HypothesisClient/Credentials/JWTSigningCredentials.php
+++ b/src/HypothesisClient/Credentials/JWTSigningCredentials.php
@@ -17,19 +17,9 @@ class JWTSigningCredentials extends Credentials
         $this->expire = $expire;
     }
 
-    public function getExpire() : int
-    {
-        return $this->expire;
-    }
-
-    public function getStartTime() : int
-    {
-        return $this->clock->time();
-    }
-
     public function getJWT(string $username) : string
     {
-        $now = $this->getStartTime();
+        $now = $this->clock->time();
         $sub = "acct:{$username}@".$this->getAuthority();
 
         $payload = [
@@ -37,7 +27,7 @@ class JWTSigningCredentials extends Credentials
             'iss' => $this->getClientId(),
             'sub' => $sub,
             'nbf' => $now,
-            'exp' => $now + $this->getExpire(),
+            'exp' => $now + $this->expire,
         ];
 
         return JWT::encode($payload, $this->getClientSecret(), 'HS256');

--- a/tests/HypothesisClient/Clock/ClockTest.php
+++ b/tests/HypothesisClient/Clock/ClockTest.php
@@ -15,6 +15,6 @@ class ClockTest extends \PHPUnit_Framework_TestCase
     public function it_can_return_the_current_time()
     {
         $clock = new Clock();
-        $this->assertEquals(time(), $clock->time());
+        $this->assertGreaterThan(0, $clock->time());
     }
 }

--- a/tests/HypothesisClient/Credentials/JWTSigningCredentialsTest.php
+++ b/tests/HypothesisClient/Credentials/JWTSigningCredentialsTest.php
@@ -15,26 +15,6 @@ class JWTSigningCredentialsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_will_have_a_start_time()
-    {
-        $credentials = new JWTSigningCredentials('foo', 'baz', 'authority', new Clock());
-        $this->assertGreaterThanOrEqual(time(), $credentials->getStartTime());
-    }
-
-    /**
-     * @test
-     */
-    public function it_may_have_an_expire_time()
-    {
-        $credentials = new JWTSigningCredentials('foo', 'baz', 'authority', new Clock());
-        $this->assertGreaterThan(0, $credentials->getExpire());
-        $credentials = new JWTSigningCredentials('foo', 'baz', 'authority', new Clock(), 100);
-        $this->assertEquals(100, $credentials->getExpire());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_generate_a_jwt_token()
     {
         $now = 1500000000;


### PR DESCRIPTION
Incidentally, also relax the Clock test expectation.