### PR TITLE
Using exec form of RUN

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -13,4 +13,4 @@ RUN composer install
 COPY . /srv/annotations
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 USER www-data
-CMD php bin/console queue:watch
+CMD ["php", "bin/console", "queue:watch"]


### PR DESCRIPTION
Results in
```
25876 ?        Sl     0:00  |   \_ docker-containerd-shim
452c8ddee9bb7342a06774a2fb4b8fae3d2e2c8be7947b8d4354833945727501
/var/run/docker/
libcontainerd/452c8ddee9bb7342a06774a2fb4b8fae3d2e2c8be7947b8d4354833945727501
docker-runc
25895 ?        Ss     0:00  |   |   \_ php bin/console queue:watch
```
rather than
```
23700 ?        Sl     0:00  |   \_ docker-containerd-shim
bf708bf25aa9ba59770873a194e9ab4d9e35aa57a8b8a204c53633c4dbc98930
/var/run/docker/
libcontainerd/bf708bf25aa9ba59770873a194e9ab4d9e35aa57a8b8a204c53633c4dbc98930
docker-runc
23725 ?        Ss     0:00  |   |   \_ /bin/sh -c php bin/console
queue:watch
23838 ?        S      0:00  |   |       \_ php bin/console queue:watch
```
simplifying how many processes we are running.