### PR TITLE
ELPP-3343 Use a container to run ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 build/
-.git
+build_images.sh
 config.php
 docker-compose.yml
+.git
+Jenkinsfile
 var/
 vendor/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 build/
-build_images.sh
 config.php
 docker-compose.yml
 .git

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,6 @@ RUN mkdir -p build && chown www-data:www-data build
 USER www-data
 RUN composer global --no-interaction require elife/proofreader-php=dev-master
 ENV PATH="/var/www/.composer/vendor/bin:${PATH}"
-COPY project_tests.sh smoke_tests.sh /srv/annotations/
+COPY .php_cs project_tests.sh smoke_tests.sh /srv/annotations/
 
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,7 @@
 FROM annotations_cli
+USER root
+RUN mkdir -p build && chown www-data:www-data build
+USER www-data
 RUN composer global --no-interaction require elife/proofreader-php=dev-master
 ENV PATH="/var/www/.composer/vendor/bin:${PATH}"
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,4 @@
+FROM annotations_cli
+RUN composer global --no-interaction require elife/proofreader-php=dev-master
+ENV PATH="/var/www/.composer/vendor/bin:${PATH}"
+CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,14 @@
 FROM annotations_cli
 USER root
+
+# extract into another image
+RUN git clone https://github.com/asm89/smoke.sh /opt/smoke.sh
+
 RUN mkdir -p build && chown www-data:www-data build
+
 USER www-data
 RUN composer global --no-interaction require elife/proofreader-php=dev-master
 ENV PATH="/var/www/.composer/vendor/bin:${PATH}"
+COPY project_tests.sh smoke_tests.sh /srv/annotations/
+
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -8,12 +8,18 @@ RUN /root/scripts/install-composer.sh
 
 WORKDIR /srv/annotations
 COPY composer.json composer.lock /srv/annotations/
-# could probably use --no-dev and other optimizations
+# could probably use --no-dev and other optimizations,
 # if we specialize annotations_ci instead
 RUN composer install
 
 # TODO: remove phpunit.xml.dist from here?
-COPY bin config phpunit.xml.dist src tests web /srv/annotations/
+# yes this is how you copy directories
+COPY bin/ /srv/annotations/bin/
+COPY config/ /srv/annotations/config/
+COPY phpunit.xml.dist /srv/annotations/
+COPY src/ /srv/annotations/src/
+COPY tests/ /srv/annotations/tests/
+COPY web/ /srv/annotations/web/
 
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 RUN mkdir -p /var/www && chown www-data:www-data /var/www

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -13,7 +13,7 @@ COPY composer.json composer.lock /srv/annotations/
 RUN composer install
 
 # TODO: remove phpunit.xml.dist from here?
-COPY bin config phpunit.xml.dist src tests web /srv/annotations
+COPY bin config phpunit.xml.dist src tests web /srv/annotations/
 
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 RUN mkdir -p /var/www && chown www-data:www-data /var/www

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -12,7 +12,9 @@ COPY composer.json composer.lock /srv/annotations/
 # if we specialize annotations_ci instead
 RUN composer install
 
-COPY . /srv/annotations
+# TODO: remove phpunit.xml.dist from here?
+COPY bin config phpunit.xml.dist src tests web /srv/annotations
+
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 RUN mkdir -p /var/www && chown www-data:www-data /var/www
 USER www-data

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -8,9 +8,12 @@ RUN /root/scripts/install-composer.sh
 
 WORKDIR /srv/annotations
 COPY composer.json composer.lock /srv/annotations/
+# could probably use --no-dev and other optimizations
+# if we specialize annotations_ci instead
 RUN composer install
 
 COPY . /srv/annotations
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
+RUN mkdir -p /var/www && chown www-data:www-data /var/www
 USER www-data
 CMD ["php", "bin/console", "queue:watch"]

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -1,5 +1,5 @@
 FROM php:7.0-fpm-jessie
-
+RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y git-core zip
 # try apt-get clean
 

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -8,8 +8,17 @@ RUN /root/scripts/install-composer.sh
 
 WORKDIR /srv/annotations
 COPY composer.json composer.lock /srv/annotations/
+# could probably use --no-dev and other optimizations?
 RUN composer install
 
-COPY . /srv/annotations
+# TODO: remove phpunit.xml.dist from here?
+# yes this is how you copy directories
+COPY bin/ /srv/annotations/bin/
+COPY config/ /srv/annotations/config/
+COPY phpunit.xml.dist /srv/annotations/
+COPY src/ /srv/annotations/src/
+COPY tests/ /srv/annotations/tests/
+COPY web/ /srv/annotations/web/
+
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 USER www-data

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ elifePipeline {
             }
 
             stage 'Container image', {
-                sh './build_images.sh'
-                sh 'chmod 777 build && docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./project_tests.sh'
+                sh 'docker-compose build'
+                sh 'chmod 777 build/ && docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
                 sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,19 @@
 elifePipeline {
     def commit
-    stage 'Checkout', {
-        checkout scm
-        commit = elifeGitRevision()
-    }
+    elifeOnNode(
+        {
+            stage 'Checkout', {
+                checkout scm
+                commit = elifeGitRevision()
+            }
+
+            stage 'Container image', {
+                sh './build_images.sh'
+                sh 'chmod 777 build && docker run -v $(pwd)/build:/srv/annotations/build annotations_ci ./project_tests.sh'
+            }
+        },
+        'elife-libraries--ci'
+    )
 
     stage 'Project tests', {
         lock('annotations--ci') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ elifePipeline {
             stage 'Container image', {
                 sh './build_images.sh'
                 sh 'chmod 777 build && docker run -v $(pwd)/build:/srv/annotations/build annotations_ci ./project_tests.sh'
+                step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
             }
         },
         'elife-libraries--ci'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ elifePipeline {
             }
 
             stage 'Container image', {
-                sh 'docker-compose build'
+                sh 'docker-compose -f docker-compose.ci.yml build'
                 sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
                 sh 'docker-compose -f docker-compose.ci.yml run ci ./smoke_tests.sh web'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ elifePipeline {
 
             stage 'Container image', {
                 sh './build_images.sh'
-                sh 'chmod 777 build && docker run -v $(pwd)/build:/srv/annotations/build annotations_ci ./project_tests.sh'
+                sh 'chmod 777 build && docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
             }
         },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,9 @@ elifePipeline {
 
             stage 'Container image', {
                 sh 'docker-compose build'
-                sh 'chmod 777 build/ && docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./project_tests.sh'
+                sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
-                sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
+                sh 'docker-compose -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
             }
         },
         'elife-libraries--ci'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ elifePipeline {
                 sh './build_images.sh'
                 sh 'chmod 777 build && docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
+                sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
             }
         },
         'elife-libraries--ci'

--- a/build_images.sh
+++ b/build_images.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-docker build -f Dockerfile.fpm -t annotations_fpm .
-docker build -f Dockerfile.cli -t annotations_cli .
-docker build -f Dockerfile.ci -t annotations_ci .

--- a/build_images.sh
+++ b/build_images.sh
@@ -2,3 +2,4 @@
 
 docker build -f Dockerfile.fpm -t annotations_fpm .
 docker build -f Dockerfile.cli -t annotations_cli .
+docker build -f Dockerfile.ci -t annotations_ci .

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,6 +5,7 @@ services:
         build: 
             context: .
             dockerfile: Dockerfile.ci
+        image: annotations_ci
         volumes:
             - ./build:/srv/annotations/build
             - ./config/container.php:/srv/annotations/config.php

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,6 +1,58 @@
 version: '3'
 
-services: 
+
+services:
+    web:
+        image: nginx:1.13.7
+        ports:
+            # TODO: must be configurable/random
+            - "8080:80"
+        volumes:
+            - ./config/nginx-default.conf:/etc/nginx/conf.d/default.conf
+            # TODO: can we avoid this by removing try_files?
+            - ./web:/srv/annotations/web
+        depends_on:
+            - fpm
+    fpm:
+        build: 
+            context: .
+            dockerfile: Dockerfile.fpm
+        image: annotations_fpm
+        volumes:
+            - ./config/container.php:/srv/annotations/config.php
+            - logs:/srv/annotations/var/logs
+        env_file:
+            - dev.env
+        depends_on:
+            - goaws
+    cli:
+        build: 
+            context: .
+            dockerfile: Dockerfile.cli
+        image: annotations_cli
+        volumes:
+            - ./config/container.php:/srv/annotations/config.php
+            - logs:/srv/annotations/var/logs
+        env_file:
+            - dev.env
+        depends_on:
+            - goaws
+    goaws:
+        image: elifealfreduser/goaws:20171024
+        ports:
+            - 4100:4100
+        volumes:
+            - ./config/goaws.yaml:/conf/goaws.yaml
+    logger:
+        image: busybox:1.27.2
+        volumes:
+            - logs:/logs
+        # be careful, this will only tail alredy existing files
+        command: tail -f /logs/all.json
+        depends_on:
+            - cli
+    # TODO: api-dummy
+    # TODO: hypothesis-dummy
     ci:
         build: 
             context: .
@@ -13,3 +65,7 @@ services:
             - dev.env
         depends_on:
             - web
+            - cli
+
+volumes:
+    logs:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,6 +7,7 @@ services:
             dockerfile: Dockerfile.ci
         volumes:
             - ./build:/srv/annotations/build
+            - ./config/container.php:/srv/annotations/config.php
         env_file:
             - dev.env
         depends_on:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services: 
+    ci:
+        build: 
+            context: .
+            dockerfile: Dockerfile.ci
+        volumes:
+            - ./build:/srv/annotations/build
+        env_file:
+            - dev.env
+        depends_on:
+            - web

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -47,7 +47,7 @@ services:
         image: busybox:1.27.2
         volumes:
             - logs:/logs
-        # be careful, this will only tail alredy existing files
+        # be careful, this will only tail already existing files
         command: tail -f /logs/all.json
         depends_on:
             - cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         build: 
             context: .
             dockerfile: Dockerfile.fpm
+        image: annotations_fpm
         volumes:
             - ./:/srv/annotations
             - ./config/container.php:/srv/annotations/config.php
@@ -27,6 +28,7 @@ services:
         build: 
             context: .
             dockerfile: Dockerfile.cli
+        image: annotations_cli
         volumes:
             - ./:/srv/annotations
             - ./config/container.php:/srv/annotations/config.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
             - logs:/srv/annotations/var/logs
         env_file:
             - dev.env
+        depends_on:
+            - goaws
     cli:
         build: 
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         image: busybox:1.27.2
         volumes:
             - logs:/logs
-        # be careful, this will only tail alredy existing files
+        # be careful, this will only tail already existing files
         command: tail -f /logs/all.json
         depends_on:
             - cli

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -4,9 +4,13 @@ set -e
 
 bin/console --version
 
+host="${1:-$(hostname)}"
+port="${2:-80}"
+
 # smoke tests need to run while allowing errors
 set +e
-smoke_url_ok $(hostname)/ping
+curl -v "$host:$port/ping"
+smoke_url_ok "$host:$port/ping"
     smoke_assert_body "pong"
 
 smoke_report


### PR DESCRIPTION
Creates an additional `annotations_ci` container to run proofreader, PHPUnit and smoke tests.

Uses exclusively `docker-compose` to interact with the Docker daemon.

Still runs the old VM-based `Project tests` build after the container build, to show both are working now.

Limitations in scope:

- do not introduce any new OS user (stick to `root` and `www-data`)
- do not introduce any eLife-wide base image (too early for that to be really reusable)
- do not introduce any separate image for multi-stage builds (e.g. to install Composer or smoke tests)
- do not push the resulting images anywhere
  
Workarounds:

- Dockerfiles `COPY` instruction
- Docker's strict volume permissions to take out XML the build result
- PhpStorm limitations (no support for multiple `docker-compose.yml` files to be merged together)
  