### PR TITLE
Remove annotations--ci EC2 instance

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=annotations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,9 @@ elifePipeline {
 
             stage 'Container image', {
                 sh 'docker-compose -f docker-compose.ci.yml build'
+            }
+
+            stage 'Project tests', {
                 sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
                 sh 'docker-compose -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
@@ -16,13 +19,6 @@ elifePipeline {
         },
         'elife-libraries--ci'
     )
-
-    stage 'Project tests', {
-        lock('annotations--ci') {
-            builderDeployRevision 'annotations--ci', commit
-            builderProjectTests 'annotations--ci', '/srv/annotations', ['/srv/annotations/build/phpunit.xml']
-        }
-    }
 
     elifeMainlineOnly {
         stage 'End2end tests', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,9 @@ elifePipeline {
             }
 
             stage 'Project tests', {
-                sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run ci ./project_tests.sh'
+                sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run --rm ci ./project_tests.sh'
                 step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
-                sh 'docker-compose -f docker-compose.ci.yml run ci ./smoke_tests.sh web'
+                sh 'docker-compose -f docker-compose.ci.yml run --rm ci ./smoke_tests.sh web'
             }
         },
         'elife-libraries--ci'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ elifePipeline {
 
     elifeOnNode(
         {
-            stage 'Container image', {
+            stage 'Build images', {
                 checkout scm
                 sh 'docker-compose -f docker-compose.ci.yml build'
             }
@@ -19,6 +19,15 @@ elifePipeline {
                     sh 'docker-compose -f docker-compose.ci.yml run --rm ci ./smoke_tests.sh web'
                 } finally {
                     sh 'docker-compose -f docker-compose.ci.yml stop'
+                }
+            }
+
+            elifeMainlineOnly {
+                stage 'Push images', {
+                    sh "docker tag annotations_cli elifesciences/annotations_cli:latest && docker push elifesciences/annotations_cli:latest"
+                    sh "docker tag annotations_cli elifesciences/annotations_cli:${commit} && docker push elifesciences/annotations_cli:${commit}"
+                    sh "docker tag annotations_fpm elifesciences/annotations_fpm:latest && docker push elifesciences/annotations_fpm:latest"
+                    sh "docker tag annotations_fpm elifesciences/annotations_fpm:${commit} && docker push elifesciences/annotations_fpm:${commit}"
                 }
             }
         },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,14 @@
 elifePipeline {
     def commit
+    stage 'Checkout', {
+        checkout scm
+        commit = elifeGitRevision()
+    }
+
     elifeOnNode(
         {
-            stage 'Checkout', {
-                checkout scm
-                commit = elifeGitRevision()
-            }
-
             stage 'Container image', {
+                checkout scm
                 sh 'docker-compose -f docker-compose.ci.yml build'
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,13 @@ elifePipeline {
             }
 
             stage 'Project tests', {
-                sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run --rm ci ./project_tests.sh'
-                step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
-                sh 'docker-compose -f docker-compose.ci.yml run --rm ci ./smoke_tests.sh web'
+                try {
+                    sh 'chmod 777 build/ && docker-compose -f docker-compose.ci.yml run --rm ci ./project_tests.sh'
+                    step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
+                    sh 'docker-compose -f docker-compose.ci.yml run --rm ci ./smoke_tests.sh web'
+                } finally {
+                    sh 'docker-compose -f docker-compose.ci.yml stop'
+                }
             }
         },
         'elife-libraries--ci'

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -17,7 +17,7 @@ services:
         build: 
             context: .
             dockerfile: Dockerfile.fpm
-        image: annotations_fpm
+        image: elifesciences/annotations_fpm
         volumes:
             - ./config/container.php:/srv/annotations/config.php
             - logs:/srv/annotations/var/logs
@@ -29,7 +29,7 @@ services:
         build: 
             context: .
             dockerfile: Dockerfile.cli
-        image: annotations_cli
+        image: elifesciences/annotations_cli
         volumes:
             - ./config/container.php:/srv/annotations/config.php
             - logs:/srv/annotations/var/logs


### PR DESCRIPTION
One less VM to maintain, and by consolidating on fewer instances we get faster builds as it may already be in a running state rather than shutdown.