### PR TITLE
Remove containers after test run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ elifePipeline {
                     sh 'docker-compose -f docker-compose.ci.yml run --rm ci ./smoke_tests.sh web'
                 } finally {
                     sh 'docker-compose -f docker-compose.ci.yml stop'
+                    sh 'docker-compose -f docker-compose.ci.yml rm -v -f'
                 }
             }
 


### PR DESCRIPTION
Containers and their volumes remain around ready to be restarted. Since we use the same name for containers on different PRs and on new commits in test-annotations, there is a conflict.

Therefore, remove containers after they have been used, along with any of their volumes. The next build will recreate them from a different image.