### PR TITLE
Mock requests to Hypothes.is

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,6 +1,7 @@
 FROM php:7.0-cli-jessie
+RUN apt-get update && apt-get install -y git-core zip libxml2-dev
 RUN docker-php-ext-install pcntl
-RUN apt-get update && apt-get install -y git-core zip
+RUN docker-php-ext-install dom
 # try apt-get clean
 
 COPY scripts/ /root/scripts

--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -171,15 +171,21 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
                 return new InMemoryStorageAdapter();
             };
 
-            $this->app['guzzle.mock.validating_storage'] = function () {
-                return new ValidatingStorageAdapter($this->app['guzzle.mock.in_memory_storage'], $this->app['elife.json_message_validator']);
-            };
+            //$this->app['guzzle.mock.validating_storage'] = function () {
+            //    return new ValidatingStorageAdapter($this->app['guzzle.mock.in_memory_storage'], $this->app['elife.json_message_validator']);
+            //};
 
             $this->app['guzzle.mock'] = function () {
-                return new MockMiddleware($this->app['guzzle.mock.validating_storage'], 'replay');
+                return new MockMiddleware($this->app['guzzle.mock.in_memory_storage'], 'replay');
             };
 
             $this->app->extend('guzzle.handler', function (HandlerStack $stack) {
+                $stack->push($this->app['guzzle.mock']);
+
+                return $stack;
+            });
+
+            $this->app->extend('hypothesis.guzzle.handler', function (HandlerStack $stack) {
                 $stack->push($this->app['guzzle.mock']);
 
                 return $stack;

--- a/tests/Annotations/AnnotationsTest.php
+++ b/tests/Annotations/AnnotationsTest.php
@@ -21,7 +21,7 @@ final class AnnotationsTest extends WebTestCase
 
         $client->request('GET', '/annotations?by=1234', [], [], ['HTTP_ACCEPT' => $type]);
         $response = $client->getResponse();
-        $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($statusCode, $response->getStatusCode(), $response->getContent());
     }
 
     public function typeProvider() : Traversable


### PR DESCRIPTION
- `hypothesis.guzzle.handler` was not mocked
- `ValidatingStorageAdapter` can't be used as-is because the Hypothes.is API does not follow its expected format
- Adding response body in error message
- Adding missing DOM extension