### PR TITLE
Enable ServiceControllerServiceProvider everywhere

### DIFF
--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -109,10 +109,10 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
         $this->app->register(new ApiProblemProvider());
         $this->app->register(new ContentNegotiationProvider());
         $this->app->register(new PingControllerProvider());
+        $this->app->register(new ServiceControllerServiceProvider());
 
         if ($this->app['debug']) {
             $this->app->register(new HttpFragmentServiceProvider());
-            $this->app->register(new ServiceControllerServiceProvider());
             $this->app->register(new TwigServiceProvider());
         }
 


### PR DESCRIPTION
Seems this provider is needed to be able to refer to container as
`"posts.controller:indexJsonAction"`:
https://silex.symfony.com/doc/2.0/providers/service_controller.html
`mock` is enabled by `config/test.php` which could explain why PHPUnit
doesn't see the problem, while in production we get a 500:
```
$ curl https://prod--gateway.elifesciences.org/annotations?by=m8nl1gze
{"exception":"Unable to find controller
\u0022controllers.annotations:annotationsAction\u0022.","stacktrace":"#0
\/srv\/annotations\/vendor\/symfony\/http-kernel\/Controller\/ControllerResolver.php(88):
Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver-\u003EcreateController(\u0027controllers.ann...\u0027)\n#1
\/srv\/annotations\/vendor\/symfony\/http-kernel\/HttpKernel.php(136):
Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver-\u003EgetController(Object(Symfony\\Component\\HttpFoundation\\Request))\n#2
\/srv\/annotations\/vendor\/symfony\/http-kernel\/HttpKernel.php(68):
Symfony\\Component\\HttpKernel\\HttpKernel-\u003EhandleRaw(Object(Symfony\\Component\\HttpFoundation\\Request),
1)\n#3
\/srv\/annotations\/vendor\/silex\/silex\/src\/Silex\/Application.php(496):
Symfony\\Component\\HttpKernel\\HttpKernel-\u003Ehandle(Object(Symfony\\Component\\HttpFoundation\\Request),
1, true)\n#4 \/srv\/annotations\/src\/Annotations\/AppKernel.php(413):
Silex\\Application-\u003Ehandle(Object(Symfony\\Component\\HttpFoundation\\Request),
1, true)\n#5 \/srv\/annotations\/web\/app_prod.php(12):
eLife\\Annotations\\AppKernel-\u003Ehandle(Object(Symfony\\Component\\HttpFoundation\\Request))\n#6
{main}","title":"Error","type":"about:blank"}
```