### PR TITLE
Latest Docker image should always be stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,7 @@ elifePipeline {
 
             elifeMainlineOnly {
                 stage 'Push images', {
-                    sh "docker push elifesciences/annotations_cli"
                     sh "docker tag elifesciences/annotations_cli elifesciences/annotations_cli:${commit} && docker push elifesciences/annotations_cli:${commit}"
-                    sh "docker push elifesciences/annotations_fpm:latest"
                     sh "docker tag elifesciences/annotations_fpm elifesciences/annotations_fpm:${commit} && docker push elifesciences/annotations_fpm:${commit}"
                 }
             }
@@ -58,6 +56,7 @@ elifePipeline {
             elifeGitMoveToBranch commit, 'approved'
             elifeOnNode(
                 {
+                    sh "docker tag elifesciences/annotations_cli:${commit} elifesciences/annotations_cli:approved && docker push elifesciences/annotations_cli:approved"
                     sh "docker tag elifesciences/annotations_fpm:${commit} elifesciences/annotations_fpm:approved && docker push elifesciences/annotations_fpm:approved"
                 },
                 'elife-libraries--ci'

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -8,6 +8,13 @@ elifePipeline {
     stage 'Deploy to prod', {
         elifeDeploySlackNotification 'annotations', 'prod'
         elifeGitMoveToBranch commit, 'master'
+        elifeOnNode(
+            {
+                sh "docker tag elifesciences/annotations_cli:${commit} elifesciences/annotations_cli:latest && docker push elifesciences/annotations_cli:latest"
+                sh "docker tag elifesciences/annotations_fpm:${commit} elifesciences/annotations_fpm:latest && docker push elifesciences/annotations_fpm:latest"
+            },
+            'elife-libraries--ci'
+        )
         builderDeployRevision 'annotations--prod', commit
         builderSmokeTests 'annotations--prod', '/srv/annotations'
     }


### PR DESCRIPTION
These tags should be pushed:

- `elifesciences/annotations:$commit` as soon as it is built on the mainline (not doing this for pull requests at the moment, to avoid creating too many tags)
- `elifesciences/annotations:approved` after the image has passed all `ci` and `end2end` tests
- `elifesciences/annotations:latest` during deploy in `prod`, which should follow shortly after. This is the default tag that should be checked out by new VMs (which are still the way we deploy in `end2end` and `prod`).