### PR TITLE
Image labels

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 COMPOSE_PROJECT_NAME=annotations
 IMAGE_TAG=develop
+# api-dummy.sha1 is deprecated in favor of:
+DEPENDENCIES_API_DUMMY=844a5f7507b2729c820f9ff861a3b34ed1da0a86

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,4 +1,5 @@
 FROM elifesciences/php_cli
+
 USER root
 RUN docker-php-ext-install pcntl
 
@@ -21,3 +22,6 @@ RUN mkdir -p var/logs && chown www-data:www-data var/logs
 RUN mkdir -p /var/www && chown www-data:www-data /var/www
 USER www-data
 CMD ["php", "bin/console", "queue:watch"]
+
+ARG dependencies_api_dummy
+LABEL org.elifesciences.dependencies.api-dummy="${dependencies_api_dummy}"

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -18,3 +18,6 @@ COPY web/ /srv/annotations/web/
 
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
 USER www-data
+
+ARG dependencies_api_dummy
+LABEL org.elifesciences.dependencies.api-dummy="${dependencies_api_dummy}"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -16,6 +16,8 @@ services:
     fpm:
         build: 
             context: .
+            args:
+                dependencies_api_dummy: "${DEPENDENCIES_API_DUMMY}"
             dockerfile: Dockerfile.fpm
         image: elifesciences/annotations_fpm:${IMAGE_TAG}
         volumes:
@@ -28,6 +30,8 @@ services:
     cli:
         build: 
             context: .
+            args:
+                dependencies_api_dummy: "${DEPENDENCIES_API_DUMMY}"
             dockerfile: Dockerfile.cli
         image: elifesciences/annotations_cli:${IMAGE_TAG}
         volumes:


### PR DESCRIPTION
Images can bring with them labels, which are arbitrary key-value pairs. The idea is we can persist in the image the api-dummy (and other dependencies) it is specified to depend on, for repeatable testing.

api-dummy doesn't have a container yet but it will be one of the next steps.