### PR TITLE
Create var/cache writable from web server

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -19,6 +19,7 @@ COPY tests/ /srv/annotations/tests/
 COPY web/ /srv/annotations/web/
 
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
+RUN mkdir -p var/cache && chown www-data:www-data var/cache
 RUN mkdir -p /var/www && chown www-data:www-data /var/www
 USER www-data
 CMD ["php", "bin/console", "queue:watch"]

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -17,6 +17,7 @@ COPY tests/ /srv/annotations/tests/
 COPY web/ /srv/annotations/web/
 
 RUN mkdir -p var/logs && chown www-data:www-data var/logs
+RUN mkdir -p var/cache && chown www-data:www-data var/cache
 USER www-data
 
 ARG dependencies_api_dummy


### PR DESCRIPTION
From
- http://htmlpurifier.org/live/configdoc/plain.html#Cache.SerializerPath
- https://github.com/ezyang/htmlpurifier/blob/17f80cd74b086a5db2a9c86368e815e43a9878b2/library/HTMLPurifier/DefinitionCache/Serializer.php#L220
the library then seems to be able to create a folder in there