### PR TITLE
Upgrade goaws to 1.0.1

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -42,7 +42,7 @@ services:
         depends_on:
             - goaws
     goaws:
-        image: elifealfreduser/goaws:20171024
+        image: elifesciences/goaws:1.0.1
         ports:
             - 4100:4100
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
         depends_on:
             - goaws
     goaws:
-        image: elifealfreduser/goaws:20171024
+        image: elifesciences/goaws:1.0.1
         ports:
             - 4100:4100
         volumes:


### PR DESCRIPTION
Also, unofficial external images we use should be mirrored on elifesciences.