### PR TITLE
Remove separate count query

### DIFF
--- a/src/Annotations/Controller/AnnotationsController.php
+++ b/src/Annotations/Controller/AnnotationsController.php
@@ -7,6 +7,7 @@ use eLife\ApiClient\Exception\ApiProblemResponse;
 use eLife\ApiSdk\ApiSdk;
 use eLife\HypothesisClient\ApiSdk as HypothesisSdk;
 use eLife\HypothesisClient\Model\Annotation;
+use eLife\HypothesisClient\Model\SearchResults;
 use eLife\HypothesisClient\Model\Token;
 use Negotiation\Accept;
 use Symfony\Component\HttpFoundation\Request;
@@ -94,12 +95,12 @@ final class AnnotationsController
 
         // Perform query to Hypothesis API.
         $content = $this->hypothesisSdk->search()->query($by, $accessToken, ($page - 1) * $perPage, $perPage, ('desc' === $order), $useDate)
-            ->then(function (array $result) use ($by, $accessToken) {
+            ->then(function (SearchResults $results) {
                 return [
-                    'total' => $this->hypothesisSdk->search()->count($by, $accessToken),
+                    'total' => $results->getTotal(),
                     'items' => array_map(function (Annotation $annotation) {
                         return $this->serializer->normalize($annotation, Annotation::class);
-                    }, $result),
+                    }, $results->getAnnotations()),
                 ];
             })->wait();
 

--- a/src/HypothesisClient/Client/Search.php
+++ b/src/HypothesisClient/Client/Search.php
@@ -4,6 +4,7 @@ namespace eLife\HypothesisClient\Client;
 
 use eLife\HypothesisClient\ApiClient\SearchClient;
 use eLife\HypothesisClient\Model\Annotation;
+use eLife\HypothesisClient\Model\SearchResults;
 use eLife\HypothesisClient\Result\Result;
 use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -37,30 +38,13 @@ final class Search
                 $descendingOrder,
                 $sort
             )
-            ->then(function (Result $result) use ($username, $accessToken) {
-                return $result;
-            })
             ->then(function (Result $result) {
-                return array_map(function (array $annotation) {
-                    return $this->serializer->denormalize($annotation, Annotation::class);
-                }, $result['rows']);
+                return new SearchResults(
+                    $result['total'],
+                    array_map(function (array $annotation) {
+                        return $this->serializer->denormalize($annotation, Annotation::class);
+                    }, $result['rows'])
+                );
             });
-    }
-
-    public function count(
-        string $username = null,
-        string $accessToken = null
-    ) : int {
-        return $this->searchClient
-            ->query(
-                [],
-                $username,
-                $accessToken,
-                0,
-                1
-            )
-            ->then(function (Result $result) use ($username, $accessToken) {
-                return $result['total'];
-            })->wait();
     }
 }

--- a/src/HypothesisClient/Model/SearchResults.php
+++ b/src/HypothesisClient/Model/SearchResults.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace eLife\HypothesisClient\Model;
+
+final class SearchResults
+{
+    private $total;
+    private $annotations;
+
+    /**
+     * @internal
+     */
+    public function __construct(int $total, array $annotations)
+    {
+        $this->total = $total;
+        $this->annotations = $annotations;
+    }
+
+    public function getTotal() : int
+    {
+        return $this->total;
+    }
+
+    public function getAnnotations() : array
+    {
+        return $this->annotations;
+    }
+}

--- a/src/HypothesisClient/Model/SearchResults.php
+++ b/src/HypothesisClient/Model/SearchResults.php
@@ -21,6 +21,9 @@ final class SearchResults
         return $this->total;
     }
 
+    /**
+     * @return Annotation[]
+     */
     public function getAnnotations() : array
     {
         return $this->annotations;

--- a/tests/Annotations/ApiTestCase.php
+++ b/tests/Annotations/ApiTestCase.php
@@ -108,20 +108,6 @@ abstract class ApiTestCase extends TestCase
                 json_encode($json)
             )
         );
-
-        // Additional call is need to get count.
-        $this->getMockStorage()->save(
-            new Request(
-                'GET',
-                "https://hypothes.is/api/search?user=$by&group=$group&offset=0&limit=1&order=desc&sort=updated",
-                $headers
-            ),
-            new Response(
-                200,
-                [],
-                json_encode($json)
-            )
-        );
     }
 
     final protected function createAnnotations($total = 10) : Traversable

--- a/tests/HypothesisClient/Client/SearchTest.php
+++ b/tests/HypothesisClient/Client/SearchTest.php
@@ -7,6 +7,7 @@ use eLife\HypothesisClient\ApiClient\SearchClient;
 use eLife\HypothesisClient\Client\Search;
 use eLife\HypothesisClient\HttpClient\HttpClient;
 use eLife\HypothesisClient\Model\Annotation;
+use eLife\HypothesisClient\Model\SearchResults;
 use eLife\HypothesisClient\Result\ArrayResult;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Request;
@@ -131,7 +132,7 @@ class SearchTest extends PHPUnit_Framework_TestCase
         ];
         $response = new FulfilledPromise(new ArrayResult(
             [
-                'total' => 0,
+                'total' => 100,
                 'rows' => $rows,
             ]
         ));
@@ -184,6 +185,6 @@ class SearchTest extends PHPUnit_Framework_TestCase
             ->with(RequestConstraint::equalTo($request))
             ->willReturn($response);
         $query = $this->search->query('username', null, 0, 20, true, 'updated')->wait();
-        $this->assertEquals($annotations, $query);
+        $this->assertEquals(new SearchResults(100, $annotations), $query);
     }
 }

--- a/tests/HypothesisClient/Model/SearchResultsTest.php
+++ b/tests/HypothesisClient/Model/SearchResultsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace tests\eLife\HypothesisClient\Model;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use eLife\HypothesisClient\Model\Annotation;
+use eLife\HypothesisClient\Model\SearchResults;
+use PHPUnit_Framework_TestCase;
+
+final class SearchResultsTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Annotation[] */
+    private $annotations;
+    /** @var SearchResults */
+    private $searchResults;
+
+    /**
+     * @before
+     */
+    public function prepareResults()
+    {
+        $this->annotations = [
+            new Annotation(
+                'id',
+                'text',
+                new DateTimeImmutable('now', new DateTimeZone('Z')),
+                new DateTimeImmutable('now', new DateTimeZone('Z')),
+                new Annotation\Document('title'),
+                new Annotation\Target('source'),
+                'uri',
+                null,
+                new Annotation\Permissions('read')
+            ),
+        ];
+        $this->searchResults = new SearchResults(3, $this->annotations);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_total()
+    {
+        $this->assertSame(3, $this->searchResults->getTotal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_annotations()
+    {
+        $this->assertEquals($this->annotations, $this->searchResults->getAnnotations());
+    }
+}


### PR DESCRIPTION
Currently these requests happen serially, which is bad for performance (should always be done in parallel wherever possible). But, there's no need for a second request anyway given the original one contains the detail required.