### PR TITLE
[WIP] Cache access tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "guzzlehttp/guzzle": "^6.3",
         "knplabs/console-service-provider": "^2.1",
         "league/commonmark": "^0.17.0",
+        "psr/simple-cache": "^1.0",
         "silex/silex": "^2.2",
+        "symfony/cache": "^4.0",
         "symfony/property-access": "^3.3",
         "symfony/serializer": "^3.3",
         "willdurand/negotiation": "^2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fa441c29ced6f4866efaa79540232d9",
+    "content-hash": "800786f8342b1e54c71f2e9249bc55a0",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1683,6 +1683,52 @@
             "time": "2017-07-23T07:32:15+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -1829,6 +1875,54 @@
             "time": "2016-10-10T12:19:37+00:00"
         },
         {
+            "name": "psr/simple-cache",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-01-02T13:31:39+00:00"
+        },
+        {
             "name": "silex/silex",
             "version": "v2.2.0",
             "source": {
@@ -1916,6 +2010,75 @@
                 "microframework"
             ],
             "time": "2017-07-23T07:40:14+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "1ebe207de664355b1699d35b12b0563c38a47b4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/1ebe207de664355b1699d35b12b0563c38a47b4e",
+                "reference": "1ebe207de664355b1699d35b12b0563c38a47b4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/cache": "~1.0",
+                "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "conflict": {
+                "symfony/var-dumper": "<3.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
+                "doctrine/dbal": "~2.4",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "time": "2018-01-03T17:15:19+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/HypothesisClient/ApiSdk.php
+++ b/src/HypothesisClient/ApiSdk.php
@@ -15,6 +15,7 @@ use eLife\HypothesisClient\Serializer\Annotation;
 use eLife\HypothesisClient\Serializer\AnnotationDenormalizer;
 use eLife\HypothesisClient\Serializer\TokenDenormalizer;
 use eLife\HypothesisClient\Serializer\UserDenormalizer;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Serializer;
 
@@ -37,7 +38,7 @@ final class ApiSdk
     /** @var UserManagementCredentials */
     private $userManagement;
 
-    public function __construct(HttpClient $httpClient, UserManagementCredentials $userManagement = null, JWTSigningCredentials $jwtSigning, string $group = '__world__')
+    public function __construct(HttpClient $httpClient, UserManagementCredentials $userManagement = null, JWTSigningCredentials $jwtSigning, string $group = '__world__', CacheInterface $cache = null)
     {
         $this->httpClient = $httpClient;
         $this->userManagement = $userManagement;
@@ -54,7 +55,7 @@ final class ApiSdk
             new UserDenormalizer(),
         ], [new JsonEncoder()]);
         $this->search = new Search(new SearchClient($this->httpClient, $this->group, []), $this->serializer);
-        $this->token = new Token(new TokenClient($this->httpClient, $this->jwtSigning, []), $this->serializer);
+        $this->token = new Token(new TokenClient($this->httpClient, $this->jwtSigning, []), $this->serializer, $cache);
         $this->users = new Users(new UsersClient($this->httpClient, $this->userManagement, []), $this->serializer);
     }
 

--- a/src/HypothesisClient/Client/Token.php
+++ b/src/HypothesisClient/Client/Token.php
@@ -6,22 +6,34 @@ use eLife\HypothesisClient\ApiClient\TokenClient;
 use eLife\HypothesisClient\Model\Token as ModelToken;
 use eLife\HypothesisClient\Result\Result;
 use GuzzleHttp\Promise\PromiseInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use function GuzzleHttp\Promise\promise_for;
 
 final class Token
 {
     private $serializer;
     private $tokenClient;
+    private $cache;
 
-    public function __construct(TokenClient $tokenClient, DenormalizerInterface $serializer)
+    public function __construct(TokenClient $tokenClient, DenormalizerInterface $serializer, CacheInterface $cache = null)
     {
         $this->tokenClient = $tokenClient;
         $this->serializer = $serializer;
+        $this->cache = $cache;
     }
 
     public function get(string $username) : PromiseInterface
     {
-        return $this->tokenClient
+        $cacheKey = "hypothesis.token.{$username}";
+
+        if ($this->cache && $token = $this->cache->get($cacheKey)) {
+            if ($token instanceof ModelToken) {
+                return promise_for($token);
+            }
+        }
+
+        $token = $this->tokenClient
             ->getToken(
                 [],
                 $username
@@ -29,5 +41,16 @@ final class Token
             ->then(function (Result $result) {
                 return $this->serializer->denormalize($result->toArray(), ModelToken::class);
             });
+
+        if ($this->cache) {
+            $token = $token
+                ->then(function (ModelToken $token) use ($cacheKey) {
+                    $this->cache->set($cacheKey, $token, (int) $token->getExpiresIn());
+
+                    return $token;
+                });
+        }
+
+        return $token;
     }
 }


### PR DESCRIPTION
It seems that the access tokens are valid for an hour (TBC), which means that if someone's paginating through their own annotations on Journal there's a request to get a token every time (and it has to come before the main search request), slowing it down.

The token should be cached for its lifetime.