### PR TITLE
Pass missing build argument with hypothesis-dummy label

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,6 +18,7 @@ services:
             context: .
             args:
                 dependencies_api_dummy: "${DEPENDENCIES_API_DUMMY}"
+                dependencies_hypothesis_dummy: "${DEPENDENCIES_HYPOTHESIS_DUMMY}"
             dockerfile: Dockerfile.fpm
         image: elifesciences/annotations_fpm:${IMAGE_TAG}
         volumes:
@@ -34,6 +35,7 @@ services:
             context: .
             args:
                 dependencies_api_dummy: "${DEPENDENCIES_API_DUMMY}"
+                dependencies_hypothesis_dummy: "${DEPENDENCIES_HYPOTHESIS_DUMMY}"
             dockerfile: Dockerfile.cli
         image: elifesciences/annotations_cli:${IMAGE_TAG}
         volumes:


### PR DESCRIPTION
Recap of the cake layers:
1. `.env` provides environment variable to `docker-compose`, only usable when rendering `docker-compose*.yml` files
2. `docker-compose.yml` passes these variables as build arguments of the `elifesciences/annotations_*` images
3. `Dockerfile.*` build the images, putting on them these arguments

https://github.com/elifesciences/annotations/pull/68 was missing point 2.