### PR TITLE
Stop ci from incorrectly overwriting the whole `aws` config key through array_merge()

### DIFF
--- a/config/ci.php
+++ b/config/ci.php
@@ -2,6 +2,4 @@
 
 $config = require __DIR__.'/dev.php';
 
-$config['aws']['queue_name'] = 'annotations--ci';
-
 return $config;


### PR DESCRIPTION
Relates to https://github.com/elifesciences/annotations-formula/pull/15 failing