### PR TITLE
ELPP-3163 Proofreader upgrade to 0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.php_cs.cache
 /build/
 /config.php
 /var/

--- a/.php_cs
+++ b/.php_cs
@@ -8,8 +8,7 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
-        // not sure what should be the equivalent
-        //'empty_return' => false,
+        'simplified_null_return' => false,
         'ordered_imports' => true,
         'return_type_declaration' => ['space_before' => 'one'],
     ])

--- a/.php_cs
+++ b/.php_cs
@@ -1,12 +1,17 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->exclude('var')
-    ->name('console')
+    ->in(__DIR__)
 ;
 
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(['-empty_return', 'ordered_use'])
-    ->finder($finder)
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        // not sure what should be the equivalent
+        //'empty_return' => false,
+        'ordered_imports' => true,
+        'return_type_declaration' => ['space_before' => 'one'],
+    ])
+    ->setFinder($finder)
 ;

--- a/.php_cs
+++ b/.php_cs
@@ -2,6 +2,7 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->exclude('var')
+    ->name('console')
     ->in(__DIR__)
 ;
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,5 @@
 ARG commit=develop
-# TODO: should be :0.2
-FROM elifesciences/proofreader-php AS proofreader
+FROM elifesciences/proofreader-php:0.2 AS proofreader
 FROM elifesciences/annotations_cli:${commit}
 ENV DEBUG=1
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,10 +1,12 @@
 ARG commit=develop
-FROM elifesciences/proofreader-php:0.1 AS proofreader
+# TODO: should be :0.2
+FROM elifesciences/proofreader-php AS proofreader
 FROM elifesciences/annotations_cli:${commit}
 ENV DEBUG=1
 
 USER root
-RUN mkdir -p build && chown www-data:www-data build
+RUN mkdir -p build && chown www-data:www-data build && \
+    touch .php_cs.cache && chown www-data:www-data .php_cs.cache
 
 USER elife
 COPY --from=proofreader --chown=elife:elife /srv/proofreader-php /srv/proofreader-php

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -73,6 +73,7 @@ services:
             dockerfile: Dockerfile.ci
         image: elifesciences/annotations_ci:${IMAGE_TAG}
         volumes:
+            # TODO: stop doing this and use docker-compose cp or similar to retrieve artifacts
             - ./build:/srv/annotations/build
             - ./config/container.php:/srv/annotations/config.php
         env_file:

--- a/src/Annotations/AppKernel.php
+++ b/src/Annotations/AppKernel.php
@@ -73,7 +73,7 @@ final class AppKernel implements ContainerInterface, HttpKernelInterface, Termin
     {
         $configFile = __DIR__.'/../../config.php';
         $config = array_merge(
-            $environment !== 'test' && file_exists($configFile) ? require $configFile : [],
+            'test' !== $environment && file_exists($configFile) ? require $configFile : [],
             require __DIR__."/../../config/{$environment}.php"
         );
 

--- a/src/Annotations/Command/QueueImportCommand.php
+++ b/src/Annotations/Command/QueueImportCommand.php
@@ -63,7 +63,7 @@ final class QueueImportCommand extends Command
         $this->output = $output;
         $entity = $input->getArgument('entity');
         // Only the configured.
-        if ($entity !== 'all' && !in_array($entity, self::$supports)) {
+        if ('all' !== $entity && !in_array($entity, self::$supports)) {
             $message = sprintf('Entity with name "%s" not supported.', $entity);
             $this->logger->error($message);
             $io->error($message);
@@ -73,7 +73,7 @@ final class QueueImportCommand extends Command
         try {
             $this->monitoring->nameTransaction($this->getName());
             $this->monitoring->startTransaction();
-            $entities = ($entity === 'all') ? self::$supports : [$entity];
+            $entities = ('all' === $entity) ? self::$supports : [$entity];
             foreach ($entities as $e) {
                 $this->{'import'.ucfirst($e)}();
             }
@@ -112,7 +112,7 @@ final class QueueImportCommand extends Command
             $progress->advance();
             try {
                 $item = $items->current();
-                if ($item === null) {
+                if (null === $item) {
                     $items->next();
                     continue;
                 }

--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -47,7 +47,7 @@ final class QueueWatchCommand extends QueueCommand
             $emails = $entity
                 ->getEmailAddresses()
                 ->filter(function (AccessControl $accessControl) {
-                    return $accessControl->getAccess() === AccessControl::ACCESS_PUBLIC;
+                    return AccessControl::ACCESS_PUBLIC === $accessControl->getAccess();
                 })
                 ->map(function (AccessControl $accessControl) {
                     return $accessControl->getValue();

--- a/src/Annotations/Serializer/HypothesisClientAnnotationNormalizer.php
+++ b/src/Annotations/Serializer/HypothesisClientAnnotationNormalizer.php
@@ -37,7 +37,7 @@ final class HypothesisClientAnnotationNormalizer implements NormalizerInterface
 
         $data = [
             'id' => $object->getId(),
-            'access' => ($object->getPermissions()->getRead() === Annotation::PUBLIC_GROUP) ? 'public' : 'restricted',
+            'access' => (Annotation::PUBLIC_GROUP === $object->getPermissions()->getRead()) ? 'public' : 'restricted',
             'created' => $created,
             'document' => [
                 'title' => $object->getDocument()->getTitle(),

--- a/src/HypothesisClient/ApiClient/ApiClient.php
+++ b/src/HypothesisClient/ApiClient/ApiClient.php
@@ -2,7 +2,6 @@
 
 namespace eLife\HypothesisClient\ApiClient;
 
-use eLife\HypothesisClient\HttpClient\HttpClient;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\UriInterface;

--- a/src/HypothesisClient/Client/Users.php
+++ b/src/HypothesisClient/Client/Users.php
@@ -53,7 +53,7 @@ final class Users
                  * attempt an update request.
                  */
                 if ($reason instanceof BadResponse) {
-                    if ($reason->getResponse()->getStatusCode() == 400) {
+                    if (400 == $reason->getResponse()->getStatusCode()) {
                         return $this->update($user);
                     }
                 }

--- a/src/HypothesisClient/Clock/Clock.php
+++ b/src/HypothesisClient/Clock/Clock.php
@@ -4,5 +4,5 @@ namespace eLife\HypothesisClient\Clock;
 
 interface Clock
 {
-    public function time() :int;
+    public function time() : int;
 }

--- a/src/HypothesisClient/Model/CanBeNew.php
+++ b/src/HypothesisClient/Model/CanBeNew.php
@@ -6,7 +6,7 @@ trait CanBeNew
 {
     protected $new = false;
 
-    public function isNew(): bool
+    public function isNew() : bool
     {
         return $this->new;
     }

--- a/tests/Annotations/ApiTestCase.php
+++ b/tests/Annotations/ApiTestCase.php
@@ -114,10 +114,10 @@ abstract class ApiTestCase extends TestCase
     {
         for ($i = 1; $i <= $total; ++$i) {
             // Allow a variety of annotation structures to be present, without being random.
-            $updated = ($i % 2 === 0);
+            $updated = (0 === $i % 2);
             $text = ($i % 4 > 0);
             $highlight = !$text ? true : (($i + 1) % 4 > 0);
-            $ancestors = ($i % 3 === 0) ? ($i % 7) + 1 : 0;
+            $ancestors = (0 === $i % 3) ? ($i % 7) + 1 : 0;
             yield $this->createAnnotation($i, $updated, $text, $highlight, $ancestors);
         }
     }


### PR DESCRIPTION
How https://github.com/elifesciences/proofreader-php/pull/7 can be used (depends on that of course, but can be built locally by rebuilding the `elifesciences/proofreader-php` image).

Supports this complex command to run the proofreader image on the host's files:
```
docker run -v $(pwd):/code -v $(pwd)/.php_cs.cache:/srv/proofreader-php/.php_cs.cache -u $(id -u) elifesciences/proofreader-php vendor/bin/php-cs-fixer fix /code/src
```

This will conflict with other PRs, so it's a proof of concept, not meant to be merged.