### PR TITLE
Improve Composer install

### DIFF
--- a/Dockerfile.composer
+++ b/Dockerfile.composer
@@ -6,10 +6,9 @@ COPY composer.json \
     composer.lock \
     ./
 
-RUN composer --no-interaction install ${composer_dev_arg} --ignore-platform-reqs --no-autoloader --no-scripts --no-suggest
+RUN composer --no-interaction install ${composer_dev_arg} --ignore-platform-reqs --no-autoloader --no-suggest --prefer-dist
 
 COPY tests/ tests/
 COPY src/ src/
 
 RUN composer --no-interaction dump-autoload ${composer_dev_arg} --classmap-authoritative
-RUN composer --no-interaction run-script post-install-cmd


### PR DESCRIPTION
Downloading repos rather than cloning saves ~12M. Also removes `--no-scripts` since I don't think we actually need it.