### PR TITLE
Make name truncation Unicode-aware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": "^7.0",
         "ext-curl": "*",
+        "ext-mbstring": "*",
         "aws/aws-sdk-php": "^3.38",
         "beberlei/assert": "^2.7",
         "elife/api-client": "^1.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06992d1b7115919da259f9f86a6a6611",
+    "content-hash": "fe98ef24a1796d4a7c75ac2b13dc1932",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1924,6 +1924,7 @@
             "keywords": [
                 "microframework"
             ],
+            "abandoned": "symfony/flex",
             "time": "2017-07-23T07:40:14+00:00"
         },
         {
@@ -4427,7 +4428,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Annotations/Command/QueueWatchCommand.php
+++ b/src/Annotations/Command/QueueWatchCommand.php
@@ -15,6 +15,8 @@ use eLife\HypothesisClient\Model\User;
 use eLife\Logging\Monitoring;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use function mb_strlen;
+use function mb_substr;
 
 final class QueueWatchCommand extends QueueCommand
 {
@@ -60,8 +62,8 @@ final class QueueWatchCommand extends QueueCommand
                 $this->logger->info(sprintf('No email address for profile "%s", backup email address created.', $id));
                 $email = $id.'@blackhole.elifesciences.org';
             }
-            if (strlen($display_name) > User::DISPLAY_NAME_MAX_LENGTH) {
-                $sanitized_display_name = substr($display_name, 0, User::DISPLAY_NAME_MAX_LENGTH);
+            if (mb_strlen($display_name) > User::DISPLAY_NAME_MAX_LENGTH) {
+                $sanitized_display_name = mb_substr($display_name, 0, User::DISPLAY_NAME_MAX_LENGTH);
                 $this->logger->info(sprintf('The display name for profile "%s" is too long and has been truncated from "%s" to "%s".', $id, $display_name, $sanitized_display_name));
             } else {
                 $sanitized_display_name = $display_name;

--- a/tests/Annotations/Command/QueueWatchCommandTest.php
+++ b/tests/Annotations/Command/QueueWatchCommandTest.php
@@ -205,17 +205,17 @@ final class QueueWatchCommandTest extends PHPUnit_Framework_TestCase
             new InternalSqsMessage('profile', 'username'),
             new Profile(
                 'username',
-                new PersonDetails('This display name is way too long', 'IndexName'),
+                new PersonDetails('This display name is way too łong', 'IndexName'),
                 new EmptySequence(),
                 new EmptySequence()
             ),
             [
                 'username' => 'username',
                 'email' => 'username@blackhole.elifesciences.org',
-                'display_name' => 'This display name is way too l',
+                'display_name' => 'This display name is way too ł',
             ],
             [
-                [LogLevel::INFO, 'The display name for profile "username" is too long and has been truncated from "This display name is way too long" to "This display name is way too l".', []],
+                [LogLevel::INFO, 'The display name for profile "username" is too long and has been truncated from "This display name is way too łong" to "This display name is way too ł".', []],
                 [LogLevel::INFO, 'No email address for profile "username", backup email address created.', []],
             ],
         ];


### PR DESCRIPTION
A Hypothesis user is currently failing to be created as their name is 30 characters long, but 33 bytes. Currently it's truncating at 30 bytes rather than 30 characters. Character 28 is bytes 30 and 31, so the truncation results in a broken character and `json_encode()` later fails since it's not valid UTF-8.